### PR TITLE
Design tweaks

### DIFF
--- a/Public/main.css
+++ b/Public/main.css
@@ -39,20 +39,29 @@ header#master-header h1 a:hover {
     color:#0076FF;
 }
 header#master-header h1 {
-    float:left;
+    float: left;
 }
 
 header#master-header ul {
-    float:right;
+    float: right;
 }
 
 header#master-header ul li {
-    float:left;
-    margin:0 20px 0 0;
+    display: inline;
+    margin-right: 20px;
 }
 
 header#master-header ul li a {
     font-weight:500;
+}
+
+@media only screen and (max-width: 600px) {
+    
+    header#master-header h1,
+    header#master-header ul {
+        float: none;
+    }
+    
 }
 
 ul#shortcuts-list {

--- a/Public/main.css
+++ b/Public/main.css
@@ -120,7 +120,7 @@ div.shortcut-card p.shortcut-summary {
 
 div.shortcut-card p.shortcut-details {
     font-size:13px;
-    color:#4C4C4C;
+    color: #6C6C6C;
 }
 
 footer#master-footer {

--- a/Public/main.css
+++ b/Public/main.css
@@ -91,7 +91,6 @@ ul#shortcuts-list li div {
 }
 
 ul#shortcuts-list li div a {
-    display: block;
     padding: 16px;
     height: calc(100% - 2 * 16px);
 }
@@ -107,7 +106,13 @@ h2.shortcut-title {
     margin-bottom:16px;
 }
 
-p.shortcut-summary {
+div.shortcut-card a {
+    display: flex;
+    flex-direction: column;
+}
+
+div.shortcut-card p.shortcut-summary {
+    flex-grow: 1;
     font-size:14px;
     color:#4C4C4C;
     margin-bottom:16px;

--- a/Public/main.css
+++ b/Public/main.css
@@ -69,6 +69,7 @@ ul#shortcuts-list {
     grid-template-columns: repeat(auto-fill, 290px);
     grid-auto-rows: auto;
     grid-gap: 1rem;
+    justify-content: space-evenly;
 }
 
 ul#shortcuts-list li {


### PR DESCRIPTION
## Left align menu on small screens
Right aligned always looks weird on small screens.

[Before](https://user-images.githubusercontent.com/7091588/42424751-9cd420ae-82df-11e8-8d93-adeeb29df5c8.png)

[After](https://user-images.githubusercontent.com/7091588/42424752-a0173d50-82df-11e8-84f4-614913193990.png)

## Center shortcut cards
Depending on the screen sizes, having the shortcuts left-aligned can produce an odd-looking gap on the right.

[Before](https://user-images.githubusercontent.com/7091588/42424822-ec6edfc2-82e0-11e8-80c3-61d1037c2d3a.png)

[After](https://user-images.githubusercontent.com/7091588/42424824-f1399dda-82e0-11e8-987d-1210d32162bb.png)

## Align shortcut details to bottom of card
So that all the details in a row are aligned with each other.

[Before](https://user-images.githubusercontent.com/7091588/42424828-09c4e0e4-82e1-11e8-8b30-ecca02493a85.png)

[After](https://user-images.githubusercontent.com/7091588/42424829-0b7c5548-82e1-11e8-8b82-43a7c90d0d70.png)

## Tweak shortcut details color
This one I'm on the fence about. The goal is to better distinguish the details text from the description, but I'm not sure if the color I've chosen is too light/too low contrast.

[Before](https://user-images.githubusercontent.com/7091588/42424829-0b7c5548-82e1-11e8-8b82-43a7c90d0d70.png)

[After](https://user-images.githubusercontent.com/7091588/42424841-4fbb6cb2-82e1-11e8-9849-353aa0602f6d.png)


---
I'd like feedback on these changes, and I'm open to changing them (especially the ones I'm unsure about).

Another thing to consider (mostly unrelated to this PR) is how to split up the CSS. Right now main.css is fairly small, but as it grows it will become increasingly annoying to maintain. I'm partial to using Sass/SCSS, both for splitting CSS files up and for the other features (nesting, namely), but I'm not sure how it (or other preprocessors) play with Vapor.