### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+os:
+    - osx
+language: generic
+sudo: required
+dist: trusty
+
+osx_image: xcode9.4
+before_install:
+    - if [ $TRAVIS_OS_NAME == "osx" ]; then
+            brew update;
+            brew tap vapor/tap;
+            brew update;
+            brew install vapor;
+        else
+            eval "$(curl -sL https://apt.vapor.sh)";
+            sudo apt-get install vapor;
+            sudo chmod -R a+rx /usr/;
+        fi
+
+script:
+    - vapor test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ before_install:
         fi
 
 script:
-    - vapor test
+    - swift build -c release
+    - swift test


### PR DESCRIPTION
Follow-up with #24: 
This PR adds [Travis](https://travis-ci.org/) to automatically catch build issues on different environments.
You may have enable Travis for this repo before it goes in effect.
A sample build: https://travis-ci.org/icodesign/Sharecuts/builds/405660083 